### PR TITLE
Update README with dependencies, installation commands, and guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $LR_{new}​=0.01 ​× \frac{8​}{16​} = 0.005$
 
 ## Download ImageNet pre-trained models for initializing DSL.
 
-Download [resnet50_rla_2283.pth](https://drive.google.com/file/d/1cetP1SdOiwznLxlBUaHG8Q8c4RIwToWW/view) (Google) [resnet50_rla_2283.pth](https://pan.baidu.com/s/1GrNxNariVpb9S5EUFW1eng) (Baidu, extract code: 5lf1) for later DSL training.
+Download [resnet50_rla_2283.pth](https://drive.google.com/file/d/1rsClfniev8a9HmQBBAvRXunVbQSYgDM8/view?usp=sharing) (Google) [resnet50_rla_2283.pth](https://pan.baidu.com/s/1GrNxNariVpb9S5EUFW1eng) (Baidu, extract code: 5lf1) for later DSL training.
 
 # Training
 For dynamically labeling the unlabeled images, original COCO dataset and VOC dataset will be converted to (`DSL-style`) datasets where annotations are saved in different json files and each image has its own annotation file. In addition, this implementation is slightly different from the original paper, where we clean the code, merge some data flow for speeding up training, add PatchShuffle also to the labeled images, and remove MetaNet for speeding up training as well, the final performance is similar as the original paper.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ We train our model on 8 V100 GPUs.
 ## General Guidelines
 ### Calculate Learning Rate:
 
-A simplified rule is the linear scaling rule:\
+**Note on Reproducing Results**
+> The training results reported in section [Testing](#testing) were obtained using **8 GPUs** with a
+> **learning rate of 0.01**. When reproducing these results with a different
+> number of GPUs, the learning rate should be adjusted according to the
+> effective batch size, which depends on both the number of GPUs and
+> `samples_per_gpu`.
+
+For this purpose, a simplified rule is the linear scaling rule:\
 <br>
 $$
 LR_{new}​=LR_{original}​× \frac{B_{original}​}{B_{new}​}

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ We train our model on 8 V100 GPUs.
 
 For this purpose, a simplified rule is the linear scaling rule:\
 <br>
-$$
-LR_{new}​=LR_{original}​× \frac{B_{original}​}{B_{new}​}
-$$
+$LR_{new}​=LR_{original}​ \times \frac{B_{new}​}{B_{original}​}$
 
-where, B = Batch Size and LR = Learning Rate 
+where, $B$ = Batch Size and $LR$ = Learning Rate 
 <br><br>
 For example, suppose the paper used:
 ```bash
@@ -61,9 +59,7 @@ samples_per_gpu = 2
 LR = 0.01
 ```
 Then
-$
-B_{original}= 2 × 8 = 16
-$
+$B_{original}= 2 \times 8 = 16$
 <br><br>
 If you use:
 ```bash
@@ -71,7 +67,7 @@ GPUs = 2
 samples_per_gpu = 4
 ```
 Then
-$B_{new}= 2 × 4 = 8$
+$B_{new}= 2 \times 4 = 8$
 <br><br>
 Therefore
 $ 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ Then
 $B_{new}= 2 \times 4 = 8$
 <br><br>
 Therefore
-$ 
-LR_{new}​=0.01 ​× \frac{8​}{16​} = 0.005
-$
+$LR_{new}​=0.01 ​× \frac{8​}{16​} = 0.005$
 
 ## Download ImageNet pre-trained models for initializing DSL.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ pip install mmdet==2.14.0 yapf==0.32.0 pycocotools imgaug
 
 We train our model on 8 V100 GPUs.
 
+## General Guidelines
+### Calculate Learning Rate:
+
+A simplified rule is the linear scaling rule:\
+<br>
+$$
+LR_{new}​=LR_{original}​× \frac{B_{original}​}{B_{new}​}
+$$
+
+where, B = Batch Size and LR = Learning Rate 
+<br><br>
+For example, suppose the paper used:
+```bash
+GPUs = 8
+samples_per_gpu = 2
+LR = 0.01
+```
+Then
+$
+B_{original}= 2 × 8 = 16
+$
+<br><br>
+If you use:
+```bash
+GPUs = 2
+samples_per_gpu = 4
+```
+Then
+$B_{new}= 2 × 4 = 8$
+<br><br>
+Therefore
+$ 
+LR_{new}​=0.01 ​× \frac{8​}{16​} = 0.005
+$
+
 ## Download ImageNet pre-trained models for initializing DSL.
 
 Download [resnet50_rla_2283.pth](https://drive.google.com/file/d/1cetP1SdOiwznLxlBUaHG8Q8c4RIwToWW/view) (Google) [resnet50_rla_2283.pth](https://pan.baidu.com/s/1GrNxNariVpb9S5EUFW1eng) (Baidu, extract code: 5lf1) for later DSL training.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ __This code is established on [mmdetection](https://github.com/open-mmlab/mmdete
 
 ```bash
 pytorch>=1.8.0
-cuda 10.2
 python>=3.8
-mmcv-full 1.3.10
-```
+mmcv-full==1.3.10
+torchvision==0.9.1
+mmdet==2.14
+yapf==0.32
+pycocotools
+imgaug
 
+```
+### Installation commands
+```bash
+
+pip install torch==1.8.1+cu111 torchvision==0.9.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
+pip install mmcv-full==1.3.10 -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.8.0/index.html
+pip install mmdet==2.14.0 yapf==0.32.0 pycocotools imgaug
+```
 ## GPU requirements
 
 We train our model on 8 V100 GPUs.

--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ cp ori_data/coco/unlabled2017/* data/semicoco/unlabel_images/full/
 ```
 
 ### 2. Download the corresponding files
-Download (`STAC_JSON.tar.gz`) and unzip it; move (`coco/annotations/instances_unlabeled2017.json`) to (`data_list/coco_semi/semi_supervised/`) dir
+Download (`STAC_JSON.tar`) and unzip it; move (`coco/annotations/instances_unlabeled2017.json`) to (`data_list/coco_semi/semi_supervised/`) dir
 ```bash
 cd ${project_root_dir}/ori_data
 wget https://storage.cloud.google.com/gresearch/ssl_detection/STAC_JSON.tar
-tar -xf STAC_JSON.tar.gz
+tar -xf STAC_JSON.tar
 
 # resulting files
 # coco/annotations/instances_unlabeled2017.json


### PR DESCRIPTION
## Description

This PR updates the README with dependencies, installation commands, guidelines, and updates the broken link.

## Changes
- Added missing dependencies under the Install dependencies section.

- Added a Note on Reproducing Results explaining how the learning rate can be adjusted when using a different number of GPUs and samples_per_gpu.

- Clarified the relationship between the effective batch size and learning rate using the simplified linear scaling rule.
- Updated the Google Drive broken link to download the pretrained model (resnet50_rla_2283.pth)
- Fixed the inconsistency in the STAC JSON download and extraction instructions:

    - The README downloads STAC_JSON.tar

   - The extraction command incorrectly refers to STAC_JSON.tar.gz

   - Updated the instructions to consistently use STAC_JSON.tar.

## Motivation
While reproducing the experiments, I encountered several issues in the README.

I  found that a few dependencies required by the project were not listed in the installation instructions. The link to download the pretrained model was broken, which I have updated.  
Additionally, the reported results were obtained using 8 GPUs with a learning rate of 0.01. When reproducing the experiments with fewer GPUs, the effective batch size changes depending on both the number of GPUs and samples_per_gpu. I therefore added a note explaining how the learning rate can be adjusted as a starting point when changing the effective batch size.